### PR TITLE
Prevent priority inversions

### DIFF
--- a/Tempura/Sources/Navigation/NavigationActions.swift
+++ b/Tempura/Sources/Navigation/NavigationActions.swift
@@ -91,7 +91,7 @@ public struct Show: NavigationSideEffect {
   public func anySideEffect(_ context: AnySideEffectContext) throws -> Any {
     guard let dependencies = context.anyDependencies as? NavigationProvider
     else { fatalError("DependenciesContainer must conform to `NavigationProvider`") }
-    try Hydra.await(dependencies.navigator.show(self.identifiersToShow, animated: self.animated, context: self.context))
+    try Hydra.await(in: .userInteractive, dependencies.navigator.show(self.identifiersToShow, animated: self.animated, context: self.context))
     return ()
   }
 }

--- a/Tempura/Sources/Navigation/NavigationActions.swift
+++ b/Tempura/Sources/Navigation/NavigationActions.swift
@@ -91,7 +91,7 @@ public struct Show: NavigationSideEffect {
   public func anySideEffect(_ context: AnySideEffectContext) throws -> Any {
     guard let dependencies = context.anyDependencies as? NavigationProvider
     else { fatalError("DependenciesContainer must conform to `NavigationProvider`") }
-    try Hydra.await(in: .userInteractive, dependencies.navigator.show(self.identifiersToShow, animated: self.animated, context: self.context))
+    try Hydra.await(dependencies.navigator.show(self.identifiersToShow, animated: self.animated, context: self.context))
     return ()
   }
 }

--- a/Tempura/Sources/Navigation/NavigationActions.swift
+++ b/Tempura/Sources/Navigation/NavigationActions.swift
@@ -35,7 +35,7 @@ public struct Navigate: NavigationSideEffect {
   public func anySideEffect(_ context: AnySideEffectContext) throws -> Any {
     guard let dependencies = context.anyDependencies as? NavigationProvider
     else { fatalError("DependenciesContainer must conform to `NavigationProvider`") }
-    try Hydra.await(dependencies.navigator.changeRoute(newRoute: self.route, animated: self.animated, context: self.context))
+    try Hydra.wait(dependencies.navigator.changeRoute(newRoute: self.route, animated: self.animated, context: self.context))
     return ()
   }
 }
@@ -91,7 +91,7 @@ public struct Show: NavigationSideEffect {
   public func anySideEffect(_ context: AnySideEffectContext) throws -> Any {
     guard let dependencies = context.anyDependencies as? NavigationProvider
     else { fatalError("DependenciesContainer must conform to `NavigationProvider`") }
-    try Hydra.await(dependencies.navigator.show(self.identifiersToShow, animated: self.animated, context: self.context))
+    try Hydra.wait(dependencies.navigator.show(self.identifiersToShow, animated: self.animated, context: self.context))
     return ()
   }
 }
@@ -161,7 +161,7 @@ public struct Hide: NavigationSideEffect {
     guard let dependencies = context.anyDependencies as? NavigationProvider
     else { fatalError("DependenciesContainer must conform to `NavigationProvider`") }
     try Hydra
-      .await(
+      .wait(
         dependencies.navigator
           .hide(self.identifierToHide, animated: self.animated, context: self.context, atomic: self.atomic)
       )

--- a/Tempura/Sources/Utilities/Hydra+Extensions.swift
+++ b/Tempura/Sources/Utilities/Hydra+Extensions.swift
@@ -1,0 +1,51 @@
+//
+//  Hydra+Extensions.swift
+//  AfreshApp
+//
+
+import Foundation
+import Hydra
+
+let awaitContext = Context.custom(queue: DispatchQueue(label: "com.tempura.waitcontext", attributes: .concurrent))
+
+extension Hydra {
+    @discardableResult
+    public static func wait<T>(in context: Context? = nil, _ promise: Promise<T>) throws -> T {
+        return try (context ?? awaitContext).wait(promise)
+    }
+}
+
+extension Context {
+
+    ///  Awaits that the given promise fulfilled with its value or throws an error if the promise fails.
+    ///
+    /// - Parameter promise: target promise
+    /// - Returns: return the value of the promise
+    /// - Throws: throw if promise fails
+    @discardableResult
+    func wait<T>(_ promise: Promise<T>) throws -> T {
+        let isNotMainQueue = self.queue != DispatchQueue.main
+
+        guard isNotMainQueue else {
+            throw PromiseError.invalidContext
+        }
+
+        var result: Result<T, Error>!
+
+        let workItem = DispatchWorkItem {}
+
+        promise
+            .then(in: self) { value in
+                result = .success(value)
+                workItem.perform()
+            }
+            .catch(in: self) { error in
+                result = .failure(error)
+                workItem.perform()
+            }
+
+        workItem.wait()
+
+        return try result.get()
+    }
+}


### PR DESCRIPTION
This fixes a runtime warning since Xcode 14 when calling `Hydra.await`. This introduces a new `Hydra.wait` function that we can use instead.

More details on the underlying issue with semaphores [here](https://developer.apple.com/forums/thread/124155) and [here](https://developer.apple.com/forums/thread/84421?answerId=251273022#251273022).

The tl;dr; is that using `DispatchSemaphore` can result in high priority threads waiting on lower priority threads. Using `DispatchWorkItem` resolves this by handling that case.